### PR TITLE
make internal soap client available for  debugging purposes

### DIFF
--- a/lib/DfpUser.js
+++ b/lib/DfpUser.js
@@ -70,6 +70,12 @@ DfpUser.prototype.getService = function (service, callback, version) {
       throw error;
     }
 
+    // Make internal soap Client available for debugging purposes
+    serviceInstance._soapClient = client;
+    serviceInstance._lastSoapRequest = () => {
+      return client.lastRequest;
+    }
+
     soap.createClient(soap_wsdl, options, function (err, client) {
       if (err) {
         console.log('Create Client Error ' + err);


### PR DESCRIPTION
When using the client I stumbled on a lot of issues regarding Soap serialization. Simply exposing the underlying soap client instance allowed me to debug and adjust my input where needed.