### PR TITLE
updates DEFAULT_VERSION to v201802

### DIFF
--- a/lib/DfpUser.js
+++ b/lib/DfpUser.js
@@ -1,4 +1,4 @@
-var DEFAULT_VERSION = 'v201702',
+var DEFAULT_VERSION = 'v201802',
   BASE_API_URL    = 'https://ads.google.com/apis/ads/publisher',
   google          = require('googleapis'),
   packageVersion  = require('../package.json').version;


### PR DESCRIPTION
Hi folks,

since the current default version will be sunset in _two days_, I've updated the _DEFAULT_VERSION_.
Please take a look at the deprecation schedule: https://developers.google.com/doubleclick-publishers/docs/deprecation

Greets from Austria,
Michael