### PR TITLE
Use google-auth-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ dfpUser.getService('LineItemService', function (err, lineItemService) {
 If you would like to use a Google [Service Account](https://developers.google.com/doubleclick-publishers/docs/service_accounts) to access DFP, you can do so by creating an instance of the JWT auth client.
 
 ```JavaScript
-var google = require('googleapis')
+var {JWT} = require('google-auth-library')
 
-var jwtClient = new google.auth.JWT(
+var jwtClient = new JWT(
   SERVICE_ACCOUNT_EMAIL,
   'path/to/key.pem',
   null,

--- a/lib/DfpUser.js
+++ b/lib/DfpUser.js
@@ -1,6 +1,6 @@
 var DEFAULT_VERSION = 'v201702',
   BASE_API_URL    = 'https://ads.google.com/apis/ads/publisher',
-  google          = require('googleapis'),
+  {OAuth2Client}  = require('google-auth-library'),
   packageVersion  = require('../package.json').version;
 
 function DfpUser(netCode, appName, version) {
@@ -120,7 +120,7 @@ DfpUser.prototype.getTokens = function (callback) {
     return this.authClient.authorize(callback);
   }
 
-  var oauthClient = new google.auth.OAuth2(this.settings.client_id, this.settings.client_secret, this.settings.redirect_url);
+  var oauthClient = new OAuth2Client(this.settings.client_id, this.settings.client_secret, this.settings.redirect_url);
   oauthClient.setCredentials({ refresh_token: this.settings.refresh_token });
   oauthClient.refreshAccessToken(callback);
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jasmine-node": "1.14.5"
   },
   "dependencies": {
-    "googleapis": "^4.0.0",
+    "google-auth-library": "^1.3.2",
     "soap": "^0.13.0"
   },
   "scripts": {


### PR DESCRIPTION
Make use of {{google-auth-library}} instead of {{googleapis}} as described in #44.
This results in smaller package-size and a more lightweight approach.

Also this updates {{google-auth-library}} to 1.3.2 (instead of 0.9.10 or similar) which already supports JWT-authentication. Current README describes this, too - but won't work if npm decides to install older version bundled with {{googleapis ^4.0.0}}.